### PR TITLE
- Update version in `package-lock.json`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "mocha-badge-generator",
-    "version": "0.5.2",
+    "version": "0.6.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {


### PR DESCRIPTION
I'm not sure if this is really of any important consequence. It happens automatically when I run a local `npm install`.

Though I tend to manually update the files, I think if one uses `npm version`, it will update the version in both `package.json` and `package-lock.json` at once (as well as perform a git commit I believe).