### PR TITLE
Done method

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "mocha-badge-generator",
-    "version": "0.5.2",
+    "version": "0.6.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -6,7 +6,7 @@ const {makeBadge} = require('./makeBadge.js');
 function BadgeGenerator(runner, options) {
     // We need the base for its calculation of `test.speed`
     Base.call(this, runner, options);
-    return new Promise((resolve, reject) => {
+    this.promise = new Promise((resolve, reject) => {
         let passes = 0;
         let failures = 0;
 
@@ -38,6 +38,14 @@ function BadgeGenerator(runner, options) {
         });
     });
 }
+
+BadgeGenerator.prototype.done = function done (failures, fn) {
+    this.promise.then(() => {
+        fn(failures);
+    }).catch((err) => {
+        console.error(err);
+    });
+};
 
 module.exports = BadgeGenerator;
 

--- a/src/makeBadge.js
+++ b/src/makeBadge.js
@@ -115,7 +115,7 @@ exports.makeBadgeFromJSONFile = (options) => {
             obj.passes += passes;
             obj.failures += failures;
             obj.duration += duration;
-            let testResults = tests;
+            let testResults = tests || [];
             if (!tests && mochawesomeTestResults) {
                 testResults = [];
                 const flattenResults = (results) => {


### PR DESCRIPTION
Builds on #14

I realized that the mechanism I had added previously to signal to my fork of `mocha-multi-reporters` (or now to the maintained `cypress-multi-reporters`) that the asynchronous work was completed had two problems:

1. It was not using the Mocha-standard `done` method mechanism (and which `cypress-multi-reporters` already supports without need for it being forked). 
2. By returning Promises, I was interfering with the runtime ability to access the `BadgeGenerator` return result as a class instance.

Since the Promise is no longer returned to the consumer, to avoid uncaught Promises in the case of errors, I catch erring Promises and log the error to stderr.

I've tested this branch on a project of mine, and it is working fine (and without the need for a cypress-multi-reporters fork).

Sorry I hadn't gotten this right the first time.